### PR TITLE
Changes made to Date.now() to "Date.parse(new Date())". As that method i...

### DIFF
--- a/jquery.stickyscroll.js
+++ b/jquery.stickyscroll.js
@@ -68,7 +68,7 @@
 
           var el = $(this),
             win = $(window),
-            id = Date.now() + index,
+            id = Date.parse(new Date()) + index,
             height = elHeight(el);
             
           el.data('sticky-id', id);


### PR DESCRIPTION
...s NOT supported on IE6/7/8 except IE9, thus throwing errors on said browsers.
