### PR TITLE
Date.now() causes stickyScroll to fail in IE <= 8. new Date().getTime() ...

### DIFF
--- a/jquery.stickyscroll.js
+++ b/jquery.stickyscroll.js
@@ -68,7 +68,7 @@
 
           var el = $(this),
             win = $(window),
-            id = Date.now() + index,
+            id = new Date.getTime() + index,
             height = elHeight(el);
             
           el.data('sticky-id', id);


### PR DESCRIPTION
...is functionally identical and is compatible with older browsers as well.
