### PR TITLE
Fixed issue with offsetheight not always returning a value

### DIFF
--- a/jquery.stickyscroll.js
+++ b/jquery.stickyscroll.js
@@ -37,7 +37,7 @@
         
         function bottomBoundary() {
           return $(document).height() - settings.container.offset().top
-            - settings.container.attr('offsetHeight');
+            - settings.container.height();
         }
 
         function topBoundary() {
@@ -45,7 +45,7 @@
         }
 
         function elHeight(el) {
-          return $(el).attr('offsetHeight');
+          return $(el).height();
         }
         
         // make sure user input is a jQuery object


### PR DESCRIPTION
Changed .attr('offsetheight') to .height() due to offsetHeight not always working and sometimes coming back as either 0 or undefined. height() always returns the correct value
