### PR TITLE
Changed .attr('offsetHeight') to [0].offsetHeight

### DIFF
--- a/jquery.stickyscroll.js
+++ b/jquery.stickyscroll.js
@@ -37,7 +37,7 @@
         
         function bottomBoundary() {
           return $(document).height() - settings.container.offset().top
-            - settings.container.attr('offsetHeight');
+            - settings.container[0].offsetHeight;
         }
 
         function topBoundary() {
@@ -45,7 +45,7 @@
         }
 
         function elHeight(el) {
-          return $(el).attr('offsetHeight');
+          return $(el)[0].offsetHeight;
         }
         
         // make sure user input is a jQuery object


### PR DESCRIPTION
Using the former would give me undefined, and therefore NaN when doing calculations.

The latter uses the jQuery objects returned element and the native DOM offsetHeight property. No need to use the jQuery .attr() in this instance.

Now my bottom container is fixed.
